### PR TITLE
All export forms except "from" now work

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "rollup:window": "rollup -c rollup.config.js -o script-type-module.js src/window/index.js",
     "prep": "cat src/window/eval.js |cat - script-type-module.js > /tmp/out && mv /tmp/out script-type-module.js",
     "build": "npm run build:worker && npm run build:window",
-    "test": "testee test/everything.html test/inline-everything.html test/import-syntax.html test/scope.html --browsers firefox"
+    "test": "testee test/everything.html test/inline-everything.html test/import-syntax.html test/export-syntax.html test/scope.html --browsers firefox"
   },
   "repository": {
     "type": "git",

--- a/script-type-module.js
+++ b/script-type-module.js
@@ -60,6 +60,17 @@ var addModuleTools = function(moduleMap){
       },
       namedExport: function(name, value){
         namespace[name] = value;
+      },
+      set: function(name, value) {
+        if(typeof name === 'object') {
+          let moduleTools = this;
+          Object.keys(name).forEach(function(key){
+            moduleTools.set(key, name[key]);
+          });
+          return;
+        }
+        namespace[name] = value;
+        return value;
       }
     };
   };

--- a/src/window/module-tools.js
+++ b/src/window/module-tools.js
@@ -11,6 +11,17 @@ export default function(moduleMap){
       },
       namedExport: function(name, value){
         namespace[name] = value;
+      },
+      set: function(name, value) {
+        if(typeof name === 'object') {
+          let moduleTools = this;
+          Object.keys(name).forEach(function(key){
+            moduleTools.set(key, name[key]);
+          });
+          return;
+        }
+        namespace[name] = value;
+        return value;
       }
     };
   };

--- a/src/worker/assignment-expression.js
+++ b/src/worker/assignment-expression.js
@@ -1,0 +1,15 @@
+import exportSet from './export-set.js';
+
+export default function(node, state, cont){
+  if(isExportName(node, state)) {
+    exportSet(node, state, node.left.name);
+    return;
+  }
+  Object.getPrototypeOf(this).AssignmentExpression(node, state, cont);
+};
+
+function isExportName(node, state){
+  let left = node.left;
+
+  return left.type === 'Identifier' && state.exportNames[left.name];
+}

--- a/src/worker/export-default-declaration.js
+++ b/src/worker/export-default-declaration.js
@@ -2,6 +2,7 @@ import nsAssignment from './namespace-assignment.js';
 
 export default function(node, state){
   state.includeTools = state.includesExports = true;
+  state.exports.push('default');
 
   nsAssignment(node, 'default');
   delete node.declaration;

--- a/src/worker/export-named-declaration.js
+++ b/src/worker/export-named-declaration.js
@@ -1,10 +1,16 @@
 import nsAssignment from './namespace-assignment.js';
+import exportSet from './export-set.js';
 
 export default function(node, state){
   state.includeTools = state.includesExports = true;
-  let name = getNameFromDeclaration(node.declaration);
 
-  nsAssignment(node, name);
+  if(!node.declaration) {
+    exportObj(node, state);
+  } else {
+    let name = getNameFromDeclaration(node.declaration);
+    //nsAssignment(node, name);
+    exportSet(node, state, name);
+  }
 
   delete node.declaration;
   delete node.specifiers;
@@ -18,4 +24,49 @@ function getNameFromDeclaration(decl) {
     case 'VariableDeclaration':
       return getNameFromDeclaration(decl.declarations[0]);
   }
+}
+
+function exportObj(node, state) {
+  let objectExpression = {
+    type: 'ObjectExpression',
+    properties: []
+  };
+
+  node.specifiers.forEach(function(specifier){
+    state.exports.push(specifier.exported.name);
+    let property = {
+      types: 'Property',
+      method: false,
+      shorthand: false,
+      computed: false,
+      key: {
+        type: 'Identifier',
+        name: specifier.exported.name
+      },
+      value: {
+        type: 'Identifier',
+        name: specifier.local.name
+      },
+      kind: 'init'
+    };
+    objectExpression.properties.push(property);
+  });
+
+  node.type = 'ExpressionStatement';
+  node.expression = {
+    type: 'CallExpression',
+    callee: {
+      type: 'MemberExpression',
+      object: {
+        type: 'Identifier',
+        name: '_moduleTools'
+      },
+      property: {
+        type: 'Identifier',
+        name: 'set'
+      },
+      computed: false
+    },
+    arguments: [objectExpression]
+  };
 }

--- a/src/worker/export-set.js
+++ b/src/worker/export-set.js
@@ -1,0 +1,48 @@
+export default function(node, state, name){
+  state.exportNames[name] = true;
+
+  let nameArg = {
+    type: 'Literal',
+    value: name,
+    raw: "'" + name + "'"
+  };
+
+  let valueArg;
+
+  let decl = node.declaration || node;
+  switch(decl.type) {
+    case 'FunctionDeclaration':
+    case 'FunctionExpression':
+    case 'Literal':
+      valueArg = decl;
+      break;
+    case 'AssignmentExpression':
+      valueArg = decl.right;
+      break;
+    default:
+      valueArg = decl.declarations[0].init;
+      // No assignment
+      if(valueArg == null) {
+        valueArg = { type: 'Identifier', name: 'undefined' };
+      }
+      break;
+  }
+
+  node.type = 'ExpressionStatement';
+  node.expression = {
+    type: 'CallExpression',
+    callee: {
+      type: 'MemberExpression',
+      object: {
+        type: 'Identifier',
+        name: '_moduleTools'
+      },
+      property: {
+        type: 'Identifier',
+        name: 'set'
+      },
+      computed: false
+    },
+    arguments: [nameArg, valueArg]
+  };
+};

--- a/src/worker/identifier.js
+++ b/src/worker/identifier.js
@@ -1,5 +1,6 @@
 export default function(node, state){
   let specifier = state.specifiers[node.name];
+
   if(specifier && !hasLocal(state, node.name)) {
     if(specifier.type === 'star') {
       node.name = specifier.ns;

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -18,6 +18,8 @@ onmessage = function(ev){
     let state = {
       anonCount: 0,
       deps: [],
+      exports: [],
+      exportNames: {},
       specifiers: {},
       vars: {},
       url: url
@@ -34,8 +36,9 @@ onmessage = function(ev){
 
     let code = escodegen.generate(ast);
     return {
+      code: code,
       deps: state.deps,
-      code: code
+      exports: state.exports
     };
   })
   .then(function(res){

--- a/src/worker/namespace-assignment.js
+++ b/src/worker/namespace-assignment.js
@@ -3,6 +3,7 @@ export default function(node, name){
   switch(node.declaration.type) {
     case 'FunctionDeclaration':
     case 'FunctionExpression':
+    case 'Literal':
       rightHandSide = node.declaration;
       break;
     case 'AssignmentExpression':

--- a/src/worker/visitors.js
+++ b/src/worker/visitors.js
@@ -1,9 +1,11 @@
-import ImportDeclaration from './import-declaration.js';
+import AssignmentExpression from './assignment-expression.js';
 import ExportDefaultDeclaration from './export-default-declaration.js';
 import ExportNamedDeclaration from './export-named-declaration.js';
 import Identifier from './identifier.js';
+import ImportDeclaration from './import-declaration.js';
 
 export default {
+  AssignmentExpression: AssignmentExpression,
   ExportDefaultDeclaration: ExportDefaultDeclaration,
   ExportNamedDeclaration: ExportNamedDeclaration,
   ImportDeclaration: ImportDeclaration,
@@ -24,6 +26,7 @@ function functionWithLocalState(fnType){
         localState.vars[node.name] = true;
       });
     }
+
     Object.getPrototypeOf(this)[fnType](node, localState, cont);
   };
 }

--- a/test/all.html
+++ b/test/all.html
@@ -25,6 +25,7 @@
   </div>
   <div class="tests">
     <iframe src="./import-syntax.html"></iframe>
+    <iframe src="./export-syntax.html"></iframe>
   </div>
   <div class="tests">
     <iframe src="./scope.html"></iframe>

--- a/test/export-syntax.html
+++ b/test/export-syntax.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html>
+<head>
+  <title>Test export syntaxes</title>
+  <script src="../script-type-module.js" defer></script>
+  <script src="../node_modules/webcomponents.js/webcomponents-lite.js" defer></script>
+  <link rel="import" href="../node_modules/mocha-test/mocha-test.html" defer>
+</head>
+<body>
+  <div id="host"></div>
+<mocha-test>
+<template>
+<script>
+(function(){
+  let importDynamic = function(specifier){
+    return new Promise(function(resolve, reject){
+      let script = document.createElement('script');
+      script.type = 'module';
+      script.onload = function(){
+        script.parentNode.removeChild(script);
+        resolve();
+      };
+      script.src = new URL(specifier, document.baseURI);
+      document.head.appendChild(script);
+    });
+  };
+
+  describe('export default', function(){
+    beforeEach(function(){
+      delete self.RESULT;
+    });
+
+    it('works', function(done){
+      importDynamic('./tests/exports/default.js')
+      .then(function(){
+        assert.equal(self.RESULT.a(), 'a');
+        assert.equal(self.RESULT.b, 'b');
+        assert.equal(self.RESULT.c, 'c');
+      })
+      .then(done, done);
+    });
+  });
+
+  describe('export let', function(){
+    beforeEach(function(){
+      delete self.RESULT;
+    });
+
+    it('works', function(done){
+      importDynamic('./tests/exports/let.js')
+      .then(function(){
+        assert.equal(self.RESULT.a, 'a');
+        assert.equal(self.RESULT.b, 'b');
+      })
+      .then(done, done);
+    });
+  });
+})();
+</script>
+</template>
+</mocha-test>
+</body>
+</html>

--- a/test/export-syntax.html
+++ b/test/export-syntax.html
@@ -55,6 +55,20 @@
       .then(done, done);
     });
   });
+
+  describe('export { }', function(){
+    beforeEach(function(){
+      delete self.RESULT;
+    });
+
+    it('export { a as b } works', function(done){
+      importDynamic('./tests/exports/object.js')
+      .then(function(){
+        assert.equal(self.RESULT.b, 'a');
+      })
+      .then(done, done);
+    });
+  });
 })();
 </script>
 </template>

--- a/test/tests/exports/default.js
+++ b/test/tests/exports/default.js
@@ -1,0 +1,9 @@
+import a from './src/default-fn.js';
+import b from './src/default-expr.js';
+import c from './src/default-obj.js';
+
+self.RESULT = {
+  a: a,
+  b: b,
+  c: c
+};

--- a/test/tests/exports/let.js
+++ b/test/tests/exports/let.js
@@ -1,0 +1,7 @@
+import { a } from './src/let-equal.js';
+import { b } from './src/let-var.js';
+
+self.RESULT = {
+  a: a,
+  b: b
+};

--- a/test/tests/exports/object.js
+++ b/test/tests/exports/object.js
@@ -1,0 +1,5 @@
+import { b } from './src/object-as.js';
+
+self.RESULT = {
+  b: b
+};

--- a/test/tests/exports/src/default-expr.js
+++ b/test/tests/exports/src/default-expr.js
@@ -1,0 +1,1 @@
+export default 'b';

--- a/test/tests/exports/src/default-fn.js
+++ b/test/tests/exports/src/default-fn.js
@@ -1,0 +1,3 @@
+export default function(){
+  return 'a';
+};

--- a/test/tests/exports/src/default-obj.js
+++ b/test/tests/exports/src/default-obj.js
@@ -1,0 +1,3 @@
+const c = 'c';
+
+export { c as default };

--- a/test/tests/exports/src/let-equal.js
+++ b/test/tests/exports/src/let-equal.js
@@ -1,0 +1,1 @@
+export let a = 'a';

--- a/test/tests/exports/src/let-var.js
+++ b/test/tests/exports/src/let-var.js
@@ -1,0 +1,3 @@
+export let b;
+
+b = 'b';

--- a/test/tests/exports/src/object-as.js
+++ b/test/tests/exports/src/object-as.js
@@ -1,0 +1,3 @@
+let a = 'a';
+
+export { a as b };


### PR DESCRIPTION
This makes all of the export forms work:

```js
export let a = 'b';

export let b;

b = 'c';

export { b as c };

export default function(){
};
```

The only that's not working is `export {} from './some-other-file.js';`.