### PR TITLE
Change type to not interfere with browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This polyfill includes:
 
 This is alpha-ish software that is tested, but not used for any real projects (yet). Check out the [tests/](https://github.com/matthewp/script-type-module/tree/master/test) folder to see what's been worked on, submit any issues you encounter.
 
+This polyfill uses a different `type` "module-polyfill" to avoid constraining browser implementations.
+
 ## Install
 
 ```
@@ -22,7 +24,7 @@ npm install script-type-module
 ```html
 <script src="./node_modules/script-type-module/polyfill.js"></script>
 
-<script type="module" src="./foo.js"></script>
+<script type="module-polyfill" src="./foo.js"></script>
 ```
 
 ## FAQ

--- a/polyfill.js
+++ b/polyfill.js
@@ -217,7 +217,7 @@ class ModuleScript {
 const forEach = Array.prototype.forEach;
 
 function importExisting(importScript){
-  let tags = document.querySelectorAll('script[type=module]');
+  let tags = document.querySelectorAll('script[type=module-polyfill]');
   forEach.call(tags, importScript);
 }
 
@@ -225,7 +225,7 @@ function observe(importScript) {
   let mo = new MutationObserver(function(mutations){
     forEach.call(mutations, function(mutation){
       forEach.call(mutation.addedNodes, function(el){
-        if(el.nodeName === 'SCRIPT' && el.type === 'module') {
+        if(el.nodeName === 'SCRIPT' && el.type === 'module-polyfill') {
           importScript(el);
         }
       });

--- a/src/window/dom.js
+++ b/src/window/dom.js
@@ -1,7 +1,7 @@
 const forEach = Array.prototype.forEach;
 
 export function importExisting(importScript){
-  let tags = document.querySelectorAll('script[type=module]');
+  let tags = document.querySelectorAll('script[type=module-polyfill]');
   forEach.call(tags, importScript);
 }
 
@@ -9,7 +9,7 @@ export function observe(importScript) {
   let mo = new MutationObserver(function(mutations){
     forEach.call(mutations, function(mutation){
       forEach.call(mutation.addedNodes, function(el){
-        if(el.nodeName === 'SCRIPT' && el.type === 'module') {
+        if(el.nodeName === 'SCRIPT' && el.type === 'module-polyfill') {
           importScript(el);
         }
       });

--- a/test/circular.html
+++ b/test/circular.html
@@ -15,7 +15,7 @@
   let importDynamic = function(specifier){
     return new Promise(function(resolve, reject){
       let script = document.createElement('script');
-      script.type = 'module';
+      script.type = 'module-polyfill';
       script.onload = function(){
         script.parentNode.removeChild(script);
         resolve();

--- a/test/errors.html
+++ b/test/errors.html
@@ -15,7 +15,7 @@
   let importDynamic = function(specifier){
     return new Promise(function(resolve, reject){
       let script = document.createElement('script');
-      script.type = 'module';
+      script.type = 'module-polyfill';
       script.onload = function(){
         script.parentNode.removeChild(script);
         resolve();

--- a/test/everything.html
+++ b/test/everything.html
@@ -10,8 +10,8 @@
   <div id="host"></div>
   <div id="host2"></div>
   <template id="loader">
-    <script type="module" src="./tests/everything/foo.js"></script>
-    <script type="module" src="./tests/everything/bar.js"></script>
+    <script type="module-polyfill" src="./tests/everything/foo.js"></script>
+    <script type="module-polyfill" src="./tests/everything/bar.js"></script>
   </template>
 <mocha-test>
 <template>

--- a/test/export-syntax.html
+++ b/test/export-syntax.html
@@ -15,7 +15,7 @@
   let importDynamic = function(specifier){
     return new Promise(function(resolve, reject){
       let script = document.createElement('script');
-      script.type = 'module';
+      script.type = 'module-polyfill';
       script.onload = function(){
         script.parentNode.removeChild(script);
         resolve();

--- a/test/import-syntax.html
+++ b/test/import-syntax.html
@@ -15,7 +15,7 @@
   let importDynamic = function(specifier){
     return new Promise(function(resolve, reject){
       let script = document.createElement('script');
-      script.type = 'module';
+      script.type = 'module-polyfill';
       script.onload = function(){
         script.parentNode.removeChild(script);
         resolve();

--- a/test/inline-everything.html
+++ b/test/inline-everything.html
@@ -10,7 +10,7 @@
   <div id="host"></div>
 <mocha-test>
 <template>
-<script type="module" id="the-module">
+<script type="module-polyfill" id="the-module">
   import './tests/everything/foo.js';
 </script>
 

--- a/test/perf/app/polyfill.html
+++ b/test/perf/app/polyfill.html
@@ -9,11 +9,11 @@
   <h1 id="host">Loading</h1>
   <h2 id="timeSpent"></h2>
   <script src="../../../polyfill.js"></script>
-  <script type="module" src="./src/main.js"></script>
+  <script type="module-polyfill" src="./src/main.js"></script>
 
   <script>
   (function(){
-    let script = document.querySelector('script[type=module]');
+    let script = document.querySelector('script[type=module-polyfill]');
     let start = performance.now();
     script.onload = function(){
       let stop = performance.now();

--- a/test/scope.html
+++ b/test/scope.html
@@ -15,7 +15,7 @@
   let importDynamic = function(specifier){
     return new Promise(function(resolve, reject){
       let script = document.createElement('script');
-      script.type = 'module';
+      script.type = 'module-polyfill';
       script.onload = function(){
         script.parentNode.removeChild(script);
         resolve();


### PR DESCRIPTION
Changing the type temporarily to `module-polyfill` to avoid clashing
with browser implementations. This does detect native support and bail
out, but there was expressed concern that this polyfill might constrain
browser implementations and I don't want that. Closes #21.

Would like a shorter type but can't think of anything shorter off the
top of my head, can change later.