### PR TITLE
Remove the check for native support

### DIFF
--- a/polyfill.js
+++ b/polyfill.js
@@ -4,19 +4,6 @@ __scriptTypeModuleEval = function(__moduleSrc){
 (function () {
 'use strict';
 
-function hasNativeSupport(){
-  var script = document.createElement('script');
-  script.type = 'module';
-  var tempVar = '_scriptModuleSupported';
-  script.textContnet = 'window._scriptModuleSupported = true;';
-  document.head.appendChild(script);
-  document.head.appendChild(script);
-  var val = !!window[tempVar];
-  delete window[tempVar];
-  script.parentNode.removeChild(script);
-  return val;
-}
-
 function currentScript() {
   return document.currentScript || document._currentScript || getCurrentScriptTheHardWay();
 }
@@ -214,17 +201,17 @@ class ModuleScript {
   }
 }
 
-const forEach = Array.prototype.forEach;
+const forEach$1 = Array.prototype.forEach;
 
 function importExisting(importScript){
   let tags = document.querySelectorAll('script[type=module-polyfill]');
-  forEach.call(tags, importScript);
+  forEach$1.call(tags, importScript);
 }
 
 function observe(importScript) {
   let mo = new MutationObserver(function(mutations){
-    forEach.call(mutations, function(mutation){
-      forEach.call(mutation.addedNodes, function(el){
+    forEach$1.call(mutations, function(mutation){
+      forEach$1.call(mutation.addedNodes, function(el){
         if(el.nodeName === 'SCRIPT' && el.type === 'module-polyfill') {
           importScript(el);
         }
@@ -316,93 +303,90 @@ function getValue(moduleScript, name, par) {
   };
 }
 
-if(!hasNativeSupport()) {
-  let cluster = new Cluster(1);
+let cluster = new Cluster(1);
 
-  let registry = new Registry();
-  let forEach = Array.prototype.forEach;
-  let anonCount = 0;
-  let pollyScript = currentScript();
-  let includeSourceMaps = pollyScript.dataset.noSm == null;
+let registry = new Registry();
+let anonCount = 0;
+let pollyScript = currentScript();
+let includeSourceMaps = pollyScript.dataset.noSm == null;
 
-  addModuleTools(registry);
+addModuleTools(registry);
 
-  function importScript(script) {
-    let url = "" + (script.src || new URL('./!anonymous_' + anonCount++, document.baseURI));
-    let src = script.src ? undefined : script.textContent;
+function importScript(script) {
+  let url = "" + (script.src || new URL('./!anonymous_' + anonCount++, document.baseURI));
+  let src = script.src ? undefined : script.textContent;
 
-    return importModule(url, src)
-    .then(function(){
-      var ev = new Event('load');
-      script.dispatchEvent(ev);
-    })
-    .then(null, function(err){
-      console.error(err);
-      var ev = new ErrorEvent('error', {
-        message: err.message,
-        filename: url
-      });
-      script.dispatchEvent(ev);
+  return importModule(url, src)
+  .then(function(){
+    var ev = new Event('load');
+    script.dispatchEvent(ev);
+  })
+  .then(null, function(err){
+    console.error(err);
+    var ev = new ErrorEvent('error', {
+      message: err.message,
+      filename: url
     });
-  }
-
-  function importModule(url, src){
-    let tree = new ModuleTree();
-
-    return fetchModule(url, src, tree)
-    .then(function(moduleScript){
-      return tree.fetchPromise.then(function(){
-        return moduleScript;
-      });
-    })
-    .then(function(moduleScript){
-      registry.link(moduleScript);
-    });
-  }
-
-  function fetchModule(url, src, tree) {
-    var promise = registry.fetchPromises.get(url);
-    if(!promise) {
-      promise = new Promise(function(resolve, reject){
-        let moduleScript = new ModuleScript(url, resolve, reject);
-        moduleScript.addToTree(tree);
-        let handler = function(msg){
-          moduleScript.addMessage(msg);
-          fetchTree(moduleScript, tree);
-          moduleScript.complete();
-        };
-        cluster.post({
-          type: 'fetch',
-          url: url,
-          src: src,
-          includeSourceMaps: includeSourceMaps
-        }, handler);
-        registry.add(moduleScript);
-      });
-      registry.fetchPromises.set(url, promise);
-    } else {
-      // See if this ModuleScript is still being fetched
-      let moduleScript = registry.get(url);
-      moduleScript.addToTree(tree);
-    }
-    return promise;
-  }
-
-  function fetchTree(moduleScript, tree) {
-    let deps = moduleScript.deps;
-    let promises = deps.map(function(url){
-      let fetchPromise = fetchModule(url, null, tree);
-      let depModuleScript = registry.get(url);
-      moduleScript.trees.forEach(function(tree){
-        depModuleScript.addToTree(tree);
-      });
-      return fetchPromise;
-    });
-    return Promise.all(promises);
-  }
-
-  importExisting(importScript);
-  observe(importScript);
+    script.dispatchEvent(ev);
+  });
 }
+
+function importModule(url, src){
+  let tree = new ModuleTree();
+
+  return fetchModule(url, src, tree)
+  .then(function(moduleScript){
+    return tree.fetchPromise.then(function(){
+      return moduleScript;
+    });
+  })
+  .then(function(moduleScript){
+    registry.link(moduleScript);
+  });
+}
+
+function fetchModule(url, src, tree) {
+  var promise = registry.fetchPromises.get(url);
+  if(!promise) {
+    promise = new Promise(function(resolve, reject){
+      let moduleScript = new ModuleScript(url, resolve, reject);
+      moduleScript.addToTree(tree);
+      let handler = function(msg){
+        moduleScript.addMessage(msg);
+        fetchTree(moduleScript, tree);
+        moduleScript.complete();
+      };
+      cluster.post({
+        type: 'fetch',
+        url: url,
+        src: src,
+        includeSourceMaps: includeSourceMaps
+      }, handler);
+      registry.add(moduleScript);
+    });
+    registry.fetchPromises.set(url, promise);
+  } else {
+    // See if this ModuleScript is still being fetched
+    let moduleScript = registry.get(url);
+    moduleScript.addToTree(tree);
+  }
+  return promise;
+}
+
+function fetchTree(moduleScript, tree) {
+  let deps = moduleScript.deps;
+  let promises = deps.map(function(url){
+    let fetchPromise = fetchModule(url, null, tree);
+    let depModuleScript = registry.get(url);
+    moduleScript.trees.forEach(function(tree){
+      depModuleScript.addToTree(tree);
+    });
+    return fetchPromise;
+  });
+  return Promise.all(promises);
+}
+
+importExisting(importScript);
+observe(importScript);
 
 }());

--- a/src/window/index.js
+++ b/src/window/index.js
@@ -1,4 +1,4 @@
-import { currentScript, hasNativeSupport } from './utils.js';
+import { currentScript } from './utils.js';
 import { encode, decode } from '../msg.js';
 import Cluster from './cluster.js';
 import addModuleTools from './module-tools.js';
@@ -7,91 +7,89 @@ import { ModuleScript, ModuleTree } from './modules.js';
 import { importExisting, observe } from './dom.js';
 import Registry from './registry.js';
 
-if(!hasNativeSupport()) {
-  let cluster = new Cluster(1);
+let cluster = new Cluster(1);
 
-  let registry = new Registry();
-  let forEach = Array.prototype.forEach;
-  let anonCount = 0;
-  let pollyScript = currentScript();
-  let includeSourceMaps = pollyScript.dataset.noSm == null;
+let registry = new Registry();
+let forEach = Array.prototype.forEach;
+let anonCount = 0;
+let pollyScript = currentScript();
+let includeSourceMaps = pollyScript.dataset.noSm == null;
 
-  addModuleTools(registry);
+addModuleTools(registry);
 
-  function importScript(script) {
-    let url = "" + (script.src || new URL('./!anonymous_' + anonCount++, document.baseURI));
-    let src = script.src ? undefined : script.textContent;
+function importScript(script) {
+  let url = "" + (script.src || new URL('./!anonymous_' + anonCount++, document.baseURI));
+  let src = script.src ? undefined : script.textContent;
 
-    return importModule(url, src)
-    .then(function(){
-      var ev = new Event('load');
-      script.dispatchEvent(ev);
-    })
-    .then(null, function(err){
-      console.error(err);
-      var ev = new ErrorEvent('error', {
-        message: err.message,
-        filename: url
-      });
-      script.dispatchEvent(ev);
+  return importModule(url, src)
+  .then(function(){
+    var ev = new Event('load');
+    script.dispatchEvent(ev);
+  })
+  .then(null, function(err){
+    console.error(err);
+    var ev = new ErrorEvent('error', {
+      message: err.message,
+      filename: url
     });
-  }
-
-  function importModule(url, src){
-    let tree = new ModuleTree();
-
-    return fetchModule(url, src, tree)
-    .then(function(moduleScript){
-      return tree.fetchPromise.then(function(){
-        return moduleScript;
-      });
-    })
-    .then(function(moduleScript){
-      registry.link(moduleScript);
-    });
-  }
-
-  function fetchModule(url, src, tree) {
-    var promise = registry.fetchPromises.get(url);
-    if(!promise) {
-      promise = new Promise(function(resolve, reject){
-        let moduleScript = new ModuleScript(url, resolve, reject);
-        moduleScript.addToTree(tree);
-        let handler = function(msg){
-          moduleScript.addMessage(msg);
-          fetchTree(moduleScript, tree);
-          moduleScript.complete();
-        };
-        cluster.post({
-          type: 'fetch',
-          url: url,
-          src: src,
-          includeSourceMaps: includeSourceMaps
-        }, handler);
-        registry.add(moduleScript);
-      });
-      registry.fetchPromises.set(url, promise);
-    } else {
-      // See if this ModuleScript is still being fetched
-      let moduleScript = registry.get(url);
-      moduleScript.addToTree(tree);
-    }
-    return promise;
-  }
-
-  function fetchTree(moduleScript, tree) {
-    let deps = moduleScript.deps;
-    let promises = deps.map(function(url){
-      let fetchPromise = fetchModule(url, null, tree);
-      let depModuleScript = registry.get(url);
-      moduleScript.trees.forEach(function(tree){
-        depModuleScript.addToTree(tree);
-      });
-      return fetchPromise;
-    });
-    return Promise.all(promises);
-  }
-
-  importExisting(importScript);
-  observe(importScript);
+    script.dispatchEvent(ev);
+  });
 }
+
+function importModule(url, src){
+  let tree = new ModuleTree();
+
+  return fetchModule(url, src, tree)
+  .then(function(moduleScript){
+    return tree.fetchPromise.then(function(){
+      return moduleScript;
+    });
+  })
+  .then(function(moduleScript){
+    registry.link(moduleScript);
+  });
+}
+
+function fetchModule(url, src, tree) {
+  var promise = registry.fetchPromises.get(url);
+  if(!promise) {
+    promise = new Promise(function(resolve, reject){
+      let moduleScript = new ModuleScript(url, resolve, reject);
+      moduleScript.addToTree(tree);
+      let handler = function(msg){
+        moduleScript.addMessage(msg);
+        fetchTree(moduleScript, tree);
+        moduleScript.complete();
+      };
+      cluster.post({
+        type: 'fetch',
+        url: url,
+        src: src,
+        includeSourceMaps: includeSourceMaps
+      }, handler);
+      registry.add(moduleScript);
+    });
+    registry.fetchPromises.set(url, promise);
+  } else {
+    // See if this ModuleScript is still being fetched
+    let moduleScript = registry.get(url);
+    moduleScript.addToTree(tree);
+  }
+  return promise;
+}
+
+function fetchTree(moduleScript, tree) {
+  let deps = moduleScript.deps;
+  let promises = deps.map(function(url){
+    let fetchPromise = fetchModule(url, null, tree);
+    let depModuleScript = registry.get(url);
+    moduleScript.trees.forEach(function(tree){
+      depModuleScript.addToTree(tree);
+    });
+    return fetchPromise;
+  });
+  return Promise.all(promises);
+}
+
+importExisting(importScript);
+observe(importScript);

--- a/src/window/utils.js
+++ b/src/window/utils.js
@@ -1,16 +1,3 @@
-export function hasNativeSupport(){
-  var script = document.createElement('script');
-  script.type = 'module';
-  var tempVar = '_scriptModuleSupported';
-  script.textContnet = 'window._scriptModuleSupported = true;';
-  document.head.appendChild(script);
-  document.head.appendChild(script);
-  var val = !!window[tempVar];
-  delete window[tempVar];
-  script.parentNode.removeChild(script);
-  return val;
-}
-
 export function currentScript() {
   return document.currentScript || document._currentScript || getCurrentScriptTheHardWay();
 }


### PR DESCRIPTION
Instead people should just use the native support when it is available
in the browsers they use for development.