### PR TITLE
Transform identifiers within a module of exported identifiers

### DIFF
--- a/src/worker/identifier.js
+++ b/src/worker/identifier.js
@@ -1,7 +1,8 @@
 export default function(node, state){
   let specifier = state.specifiers[node.name];
+  let localVar = hasLocal(state, node.name);
 
-  if(specifier && !hasLocal(state, node.name)) {
+  if(specifier && !localVar) {
     if(specifier.type === 'star') {
       node.name = specifier.ns;
     } else {
@@ -18,6 +19,26 @@ export default function(node, state){
       node.computed = false;
       delete node.name;
     }
+  } else if(state.exports[node.name] && !localVar) {
+    node.type = 'MemberExpression';
+    node.object = {
+      type: 'MemberExpression',
+      object: {
+        type: 'Identifier',
+        name: '_moduleTools'
+      },
+      property: {
+        type: 'Identifier',
+        name: 'namespace'
+      },
+      computed: false
+    };
+    node.property = {
+      type: 'Identifier',
+      name: node.name
+    };
+    node.computed = false;
+    delete node.name;
   }
 };
 

--- a/test/export-syntax.html
+++ b/test/export-syntax.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Test export syntaxes</title>
-  <script src="../polyfill.js" defer></script>
+  <script src="../polyfill.js" defer data-no-sm></script>
   <script src="../node_modules/webcomponents.js/webcomponents-lite.js" defer></script>
   <link rel="import" href="../node_modules/mocha-test/mocha-test.html" defer>
 </head>
@@ -57,6 +57,7 @@
       .then(function(){
         assert.equal(self.RESULT.a, 'a');
         assert.equal(self.RESULT.b, 'b');
+        assert.equal(self.RESULT.c(), 'c');
       })
       .then(done, done);
     });

--- a/test/tests/exports/let.js
+++ b/test/tests/exports/let.js
@@ -1,7 +1,9 @@
 import { a } from './src/let-equal.js';
 import { b } from './src/let-var.js';
+import { c } from './src/let-use-export.js';
 
 self.RESULT = {
-  a: a,
-  b: b
+  a,
+  b,
+  c
 };

--- a/test/tests/exports/src/let-use-export.js
+++ b/test/tests/exports/src/let-use-export.js
@@ -1,0 +1,9 @@
+export let d;
+
+d = 'c';
+
+export function c(){
+  return d;
+}
+
+

--- a/worker.js
+++ b/worker.js
@@ -8859,8 +8859,9 @@ function exportFrom(node, state){
 
 var Identifier = function(node, state){
   let specifier = state.specifiers[node.name];
+  let localVar = hasLocal(state, node.name);
 
-  if(specifier && !hasLocal(state, node.name)) {
+  if(specifier && !localVar) {
     if(specifier.type === 'star') {
       node.name = specifier.ns;
     } else {
@@ -8877,6 +8878,26 @@ var Identifier = function(node, state){
       node.computed = false;
       delete node.name;
     }
+  } else if(state.exports[node.name] && !localVar) {
+    node.type = 'MemberExpression';
+    node.object = {
+      type: 'MemberExpression',
+      object: {
+        type: 'Identifier',
+        name: '_moduleTools'
+      },
+      property: {
+        type: 'Identifier',
+        name: 'namespace'
+      },
+      computed: false
+    };
+    node.property = {
+      type: 'Identifier',
+      name: node.name
+    };
+    node.computed = false;
+    delete node.name;
   }
 }
 


### PR DESCRIPTION
When an export identifier is used within the module, that usage is now transformed to come from the module's namespace object. Uses the same logic to transform the use of import identifiers.

Fixes #31